### PR TITLE
Explicity set escope dependency version to 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-1": "^6.5.0",
+    "escope": "^3.3.0",
     "eslint": "1.4.1",
     "eslint-config-rackt": "1.0.0",
     "eslint-plugin-react": "3.3.2",


### PR DESCRIPTION
To fix this issue (when running `npm test`): https://github.com/babel/babel-eslint/issues/243
